### PR TITLE
fix BufLeave (broke exiting from CtrlP)

### DIFF
--- a/plugin/vimteractive.vim
+++ b/plugin/vimteractive.vim
@@ -104,4 +104,4 @@ endfunction
 autocmd BufEnter * if &buftype == 'terminal' | call feedkeys("\<C-W>N")  | endif
 
 " Switch back to terminal mode when exiting
-autocmd BufLeave * if &buftype == 'terminal' | silent! normal! i  | endif
+autocmd BufLeave * if &buftype == 'terminal' | execute "silent! normal! i"  | endif


### PR DESCRIPTION
`normal! i` in BufLeave somehow broke the CtrlP plugin (maybe others too) whose window could not be closed again and managed to disable all leader mappings after CtrlP stranded this way - strange...

Wrapping it as `execute "normal! i"` fixed this.